### PR TITLE
Adds 23/24 module reviews for MA3J3, MA377, MA3E1, and MA3D5

### DIFF
--- a/_pages/module_reviews.md
+++ b/_pages/module_reviews.md
@@ -782,8 +782,7 @@ The exam was fairly hard but doable, although this may change with the new lectu
     <!-- -->
     <div class="card-header" id="headingMA3D5">
       <h2 class="m-0">
-        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3D5" aria-expanded="false" aria-controls="collapseMA3D5" id="MA3D5"
-        disabled>
+        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3D5" aria-expanded="false" aria-controls="collapseMA3D5" id="MA3D5">
           <large><a href="#MA3D5">MA3D5 Galois Theory</a></large>
         </button>
       </h2>
@@ -814,8 +813,7 @@ I found this module fascinating, but rather disorganised (although that may have
     <!-- -->
     <div class="card-header" id="headingMA3E1">
       <h2 class="m-0">
-        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3E1" aria-expanded="false" aria-controls="collapseMA3E1" id="MA3E1"
-        disabled>
+        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3E1" aria-expanded="false" aria-controls="collapseMA3E1" id="MA3E1">
           <large><a href="#MA3E1">MA3E1 Groups and Representations</a></large>
         </button>
       </h2>
@@ -1053,8 +1051,7 @@ The lecture notes are excellent; the lectures were less so, I found, although pa
     <!-- -->
     <div class="card-header" id="headingMA3J3">
       <h2 class="m-0">
-        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3J3" aria-expanded="false" aria-controls="collapseMA3J3" id="MA3J3"
-        disabled>
+        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3J3" aria-expanded="false" aria-controls="collapseMA3J3" id="MA3J3>
           <large><a href="#MA3J3">MA3J3 Bifurcations, Catastrophes, and Symmetry</a></large>
         </button>
       </h2>

--- a/_pages/module_reviews.md
+++ b/_pages/module_reviews.md
@@ -389,7 +389,7 @@ Note that only the most popular optional external modules have been listed below
         <br/>
         This module — optional core for BSc (along with MA266) and (thankfully) core for MMath — is a fantastic choice for anyone who has enjoyed previous courses in analysis, vector calculus, and partial differential equations, and is invaluable for any future analysis, modelling, or applied mathematics modules! The module begins by rehashing some material from Analysis 3 — in particular, the definitions of continuity and differentiability in <i>n</i>-dimensions; a comparison of the directional, frechet and partial derivatives; operator norms; and dual spaces. You are then introduced to the powerful inverse and implicit function theorems, which are proved thoroughly and then are demonstrated in their use with multiple examples. The later half of the module then explores some topics previously seen in Modelling 2, but focusses on proof as well as application: the notion of the Hessian, the commutativity of partial derivatives, the second order Taylor expansion, critical point classification, integrating in higher dimensions (i.e. higher dimensional Riemann integration) and Fubini's theorem, the notion of flux, and the divergence theorem are all studied rigorously and proved. The notion of measure is also first hinted at along the way, with the idea of measure zero sets.
         <br/><br/>
-        The notes are very well written and make use of a good balance of proofs and examples, and work well with the worksheets - an excellent course text recommended by the lecturer, <i> Calculus on Manifolds</i> by Spivak, also complements these well. The greatest strength of this module however is the lecturer himself, who takes a potentially very difficult subject which you would expect to be unintuitive and makes it not just seem intuitive, but also fascinating and worthy of further exploration - the lectures for this were some of the best I have attended in my 2 years here so far. The 23/24 exam for this module was a very good mix of bookwork and computation, but this was the first year this module has run in its current form, so future papers might be slightly different. While similar, the question style especially is rather different to the prior equivalent of this module, so there might not be many past papers available, but the worksheets are very good for practice. If you are a BSc student or a joint degree at all interested in potentially doing any analysis, partial differential equations, physics, or mathematical modelling that involves vector calculus in third year, it is not just recommended but essential to take this module (it is core for MMath for a reason) and I would thoroughly recommend it!
+        The notes are very well written and make use of a good balance of proofs and examples, and work well with the worksheets — an excellent course text recommended by the lecturer, <i> Calculus on Manifolds</i> by Spivak, also complements these well. The greatest strength of this module however is the lecturer himself, who takes a potentially very difficult subject which you would expect to be unintuitive and makes it not just seem intuitive, but also fascinating and worthy of further exploration — the lectures for this were some of the best I have attended in my 2 years here so far. The 23/24 exam for this module was a very good mix of bookwork and computation, but this was the first year this module has run in its current form, so future papers might be slightly different. While similar, the question style especially is rather different to the prior equivalent of this module, so there might not be many past papers available, but the worksheets are very good for practice. If you are a BSc student or a joint degree at all interested in potentially doing any analysis, partial differential equations, physics, or mathematical modelling that involves vector calculus in third year, it is not just recommended but essential to take this module (it is core for MMath for a reason) and I would thoroughly recommend it!
       </div>
     </div>
     <!-- -->
@@ -677,10 +677,13 @@ Note that only the most popular optional external modules have been listed below
       <div class="card-body">
         <large class="text-muted">23/24</large>
         <br/>
-        This is a module where you will very much want to go to lectures - the pace is fairly fast and the Modules half of the module title does a lot of heavy lifting. There is also a fairly long section on division rings, which you may find interesting if you have ever looked at quaternions before.
-        <br/><br/>
-        There are also lots of smaller topics, often just strung together because they are vaguely related. On the other hand, there aren't many long nasty proofs, and if you enjoy following your nose to prove definitions make sense, you will definitely like this module. I recommend this module for anyone who enjoys learning lots of definitions.
-The exam was fairly hard but doable, although this may change with the new lecturer. I suggest trying the past papers well in advance.
+        This is a module where you will very much want to go to lectures — the pace is fairly fast and the <i>Modules</i> half of the module title does a lot of heavy lifting. There is also a fairly long section on division rings, which you may find interesting if you have ever looked at quaternions before.
+        <br/>
+        <br/>
+        There are also lots of smaller topics — often just strung together because they are vaguely related. On the other hand, there aren't many long nasty proofs, and if you enjoy following your nose to prove that definitions make sense, you will definitely like this module. I recommend this module for anyone who enjoys learning lots of definitions.
+        <br/>
+        <br/>
+        The exam was fairly hard but doable, although this may change with the new lecturer. I suggest trying the past papers well in advance.
       </div>
     </div>
     <!-- -->
@@ -791,7 +794,7 @@ The exam was fairly hard but doable, although this may change with the new lectu
       <div class="card-body">
         <large class="text-muted">23/24</large>
         <br/>
-I found this module fascinating, but rather disorganised (although that may have changed as Gavin is no longer lecturing). The exam was really great, and the example sheets were also very nice. The main focus of the module is field extensions and using them to do things like prove that there is no general formula for the roots of a quintic; it's a really nice module if you're interested why such things are true. That said, there are a lot of new definitions, and a fair bit of time is spent reviewing stuff from previous modules.
+        I found this module fascinating, but rather disorganised (although that may have changed as Gavin is no longer lecturing). The exam was really great, and the example sheets were also very nice. The main focus of the module is field extensions and using them to do things like proving that there is no general formula for the roots of a quintic; it's a really nice module if you're interested why such things are true. That said, there are a lot of new definitions, and a fair bit of time is spent reviewing stuff from previous modules.
       </div>
     </div>
     <!-- -->
@@ -822,9 +825,10 @@ I found this module fascinating, but rather disorganised (although that may have
       <div class="card-body">
         <large class="text-muted">23/24</large>
         <br/>
-The module starts, as most algebra modules do, with a sweeping review of basic definitions, but after that it picks up and dives straight into group representations and their characters (these are less scary than they may sound). You will encounter lots of new definitions, but nothing particularly onerous is done with them theoretically; the module is mostly engaged in the practical finding of representations and characters. 
-      <br/><br/>
-The lecture notes are excellent; the lectures were less so, I found, although part of it was that they were either late or early and everyone was tired.
+        The module starts — as most algebra modules do — with a sweeping review of basic definitions; but after that, it picks up and dives straight into group representations and their characters (these are less scary than they may sound). You will encounter lots of new definitions, but nothing particularly onerous is done with them theoretically; the module is mostly engaged in the practical finding of representations and characters. 
+        <br/>
+        <br/>
+        The lecture notes are excellent; the lectures were less so, I found — although part of it was that they were either late or early and everyone was tired.
       </div>
     </div>
     <!-- -->
@@ -1062,7 +1066,7 @@ The lecture notes are excellent; the lectures were less so, I found, although pa
         <br/>
         The best part of this module for me was Dave. In all seriousness, it is very interesting. If you are expecting a "nice", practical ODEs module, though, this is not it; there is lots of theory and there are several Big Theorems, many of which are helpfully left unproved to make them more difficult to remember.
   <br/><br/>
-    As the module name suggests, it is split into three sections: bifurcations, catastrophes, and symmetries. Bifurcations are when the number or type of fixed points changes; expect to draw lots of diagrams. In the catastrophes section you will also draw lots of diagrams, but in between the diagrams there is a lot of fairly dense theory. The symmetries section is essentially just some applied group theory, along with bug facts - I suspect it's mostly there so we can talk about bug gaits. 
+    As the module name suggests, it is split into three sections: bifurcations, catastrophes, and symmetries. Bifurcations are when the number or type of fixed points changes; expect to draw lots of diagrams. In the catastrophes section you will also draw lots of diagrams, but in between the diagrams there is a lot of fairly dense theory. The symmetries section is essentially just some applied group theory, along with bug facts — I suspect it's mostly there so we can talk about bug gaits. 
     <br/><br/>
     The exam tends to be a fair mix of all three topics and very doable. The papers are not in a strict format but they are usually fairly similar from one year to the next.
       </div>

--- a/_pages/module_reviews.md
+++ b/_pages/module_reviews.md
@@ -1055,7 +1055,7 @@ Note that only the most popular optional external modules have been listed below
     <!-- -->
     <div class="card-header" id="headingMA3J3">
       <h2 class="m-0">
-        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3J3" aria-expanded="false" aria-controls="collapseMA3J3" id="MA3J3>
+        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA3J3" aria-expanded="false" aria-controls="collapseMA3J3" id="MA3J3">
           <large><a href="#MA3J3">MA3J3 Bifurcations, Catastrophes, and Symmetry</a></large>
         </button>
       </h2>

--- a/_pages/module_reviews.md
+++ b/_pages/module_reviews.md
@@ -668,17 +668,19 @@ Note that only the most popular optional external modules have been listed below
     <!-- -->
     <div class="card-header" id="headingMA377">
       <h2 class="m-0">
-        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA377" aria-expanded="false" aria-controls="collapseMA377" id="MA377"
-        disabled>
+        <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseMA377" aria-expanded="false" aria-controls="collapseMA377" id="MA377">
           <large><a href="#MA377">MA377 Rings and Modules</a></large>
         </button>
       </h2>
     </div>
     <div id="collapseMA377" class="collapse" aria-labelledby="headingMA377" data-parent="#accordionY3maths">
       <div class="card-body">
-        <large class="text-muted">YY/YY</large>
+        <large class="text-muted">23/24</large>
         <br/>
-        review here
+        This is a module where you will very much want to go to lectures - the pace is fairly fast and the Modules half of the module title does a lot of heavy lifting. There is also a fairly long section on division rings, which you may find interesting if you have ever looked at quaternions before.
+        <br/><br/>
+        There are also lots of smaller topics, often just strung together because they are vaguely related. On the other hand, there aren't many long nasty proofs, and if you enjoy following your nose to prove definitions make sense, you will definitely like this module. I recommend this module for anyone who enjoys learning lots of definitions.
+The exam was fairly hard but doable, although this may change with the new lecturer. I suggest trying the past papers well in advance.
       </div>
     </div>
     <!-- -->
@@ -788,9 +790,9 @@ Note that only the most popular optional external modules have been listed below
     </div>
     <div id="collapseMA3D5" class="collapse" aria-labelledby="headingMA3D5" data-parent="#accordionY3maths">
       <div class="card-body">
-        <large class="text-muted">YY/YY</large>
+        <large class="text-muted">23/24</large>
         <br/>
-        review here
+I found this module fascinating, but rather disorganised (although that may have changed as Gavin is no longer lecturing). The exam was really great, and the example sheets were also very nice. The main focus of the module is field extensions and using them to do things like prove that there is no general formula for the roots of a quintic; it's a really nice module if you're interested why such things are true. That said, there are a lot of new definitions, and a fair bit of time is spent reviewing stuff from previous modules.
       </div>
     </div>
     <!-- -->
@@ -820,9 +822,11 @@ Note that only the most popular optional external modules have been listed below
     </div>
     <div id="collapseMA3E1" class="collapse" aria-labelledby="headingMA3E1" data-parent="#accordionY3maths">
       <div class="card-body">
-        <large class="text-muted">YY/YY</large>
+        <large class="text-muted">23/24</large>
         <br/>
-        review here
+The module starts, as most algebra modules do, with a sweeping review of basic definitions, but after that it picks up and dives straight into group representations and their characters (these are less scary than they may sound). You will encounter lots of new definitions, but nothing particularly onerous is done with them theoretically; the module is mostly engaged in the practical finding of representations and characters. 
+      <br/><br/>
+The lecture notes are excellent; the lectures were less so, I found, although part of it was that they were either late or early and everyone was tired.
       </div>
     </div>
     <!-- -->
@@ -1057,9 +1061,13 @@ Note that only the most popular optional external modules have been listed below
     </div>
     <div id="collapseMA3J3" class="collapse" aria-labelledby="headingMA3J3" data-parent="#accordionY3maths">
       <div class="card-body">
-        <large class="text-muted">YY/YY</large>
+        <large class="text-muted">23/24</large>
         <br/>
-        review here
+        The best part of this module for me was Dave. In all seriousness, it is very interesting. If you are expecting a "nice", practical ODEs module, though, this is not it; there is lots of theory and there are several Big Theorems, many of which are helpfully left unproved to make them more difficult to remember.
+  <br/><br/>
+    As the module name suggests, it is split into three sections: bifurcations, catastrophes, and symmetries. Bifurcations are when the number or type of fixed points changes; expect to draw lots of diagrams. In the catastrophes section you will also draw lots of diagrams, but in between the diagrams there is a lot of fairly dense theory. The symmetries section is essentially just some applied group theory, along with bug facts - I suspect it's mostly there so we can talk about bug gaits. 
+    <br/><br/>
+    The exam tends to be a fair mix of all three topics and very doable. The papers are not in a strict format but they are usually fairly similar from one year to the next.
       </div>
     </div>
     <!-- -->


### PR DESCRIPTION
## Description

Adds module reviews for the 23/24 modules: MA3J3 Bifurcations, Catastrophes, and Symmetries; MA3D5 Galois Theory; MA3E1 Groups and Representations; and MA377 Rings and Modules.

## Types of Changes

- [ ] New post
- [ ] Essay contribution
- [ X] Module Review contribution
- [ ] Bugfix
- [ ] Added graphics
- [ ] New feature
- [ ] Other

## Issues Relevant to this PR

N/A

## Checks

<!--- Check whichever is applicable. -->
- [ ] I have built and tested these changes locally or otherwise, and confirm that they work and don't break existing functionality.
- [X ] I have not built these changes locally or otherwise, and require someone to review these changes for me.
