### PR TITLE
fixing a typo of an incorrect module code

### DIFF
--- a/_pages/module-guides.md
+++ b/_pages/module-guides.md
@@ -52,7 +52,7 @@ tbody{
     <td><a target="_blank" href="./assets/WMX Guides/MA133 Differential Equations.pdf">MA133 Differential Equations</a></td>
   </tr>
   <tr>
-    <td>MA134<br/>[MA146]</td>
+    <td>MA134<br/>[MA144]</td>
     <td><a target="_blank" href="./assets/WMX Guides/MA134 Geometry and Motion.pdf">MA134 Geometry and Motion</a></td>
   </tr>
   <tr>

--- a/_pages/module-guides.md
+++ b/_pages/module-guides.md
@@ -52,7 +52,7 @@ tbody{
     <td><a target="_blank" href="./assets/WMX Guides/MA133 Differential Equations.pdf">MA133 Differential Equations</a></td>
   </tr>
   <tr>
-    <td>MA133<br/>[MA146]</td>
+    <td>MA134<br/>[MA146]</td>
     <td><a target="_blank" href="./assets/WMX Guides/MA134 Geometry and Motion.pdf">MA134 Geometry and Motion</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the title above. -->

## Description

Fixing a typo in the legacy module guides page where the guide for MA134 was labeled as being for MA133.

## Types of Changes

- [ ] New post
- [ ] Essay contribution
- [ ] Module Review contribution
- [ ] Book Review contribution
- [ ] Added graphics
- [ ] New feature
- [x] Bugfix
- [ ] Other

## Issues Relevant to this PR

<!--- Link relevant issues here (if any). -->

## Checks

<!--- Check whichever is applicable. -->
- [x] I have built and tested these changes locally or otherwise, and confirm that they work and don't break existing functionality.
- [ ] I have not built these changes locally or otherwise, and require someone to review these changes for me.
